### PR TITLE
Fix reversed order of evaluation of args in call to LineFollow::config

### DIFF
--- a/src/ArduinoRobotMotorBoard.cpp
+++ b/src/ArduinoRobotMotorBoard.cpp
@@ -73,6 +73,10 @@ void RobotMotorBoard::parseCommand(){
 	int value;
 	int speedL;
 	int speedR;
+	uint8_t KP;
+	uint8_t KD;
+	uint8_t robotSpeed;
+	uint8_t integrationTime;
 	if(this->messageIn.receiveData()){
 		//Serial.println("data received");
 		uint8_t command=messageIn.readByte();
@@ -119,12 +123,11 @@ void RobotMotorBoard::parseCommand(){
 				pauseMode(messageIn.readByte());//onOff state
 				break;
 			case COMMAND_LINE_FOLLOW_CONFIG:
-				LineFollow::config(
-					messageIn.readByte(),	//KP
-					messageIn.readByte(),	//KD
-					messageIn.readByte(),	//robotSpeed
-					messageIn.readByte()	//IntegrationTime
-				);
+				KP = messageIn.readByte();
+				KD = messageIn.readByte();
+				robotSpeed = messageIn.readByte();
+				integrationTime = messageIn.readByte();
+				LineFollow::config(KP, KD, robotSpeed, integrationTime);
 				break;
 		}
 	}


### PR DESCRIPTION
In C/C++ the order of evaluation of function arguments is unspecified.

In the particular case it was assumed that the calls to messageIn.readByte() in LineFollow::config() are evaluated from left to right. But that is not the case. In fact the evaluation order is from right to left with avr-gcc. At the end that caused the line follower application to work improperly.

The problem is solved by using additional variables like in the other cases of calls to messageIn.readByte() or messageIn.readInt().